### PR TITLE
fix: edit main page animation and carousel

### DIFF
--- a/app/(main)/(dark)/page.tsx
+++ b/app/(main)/(dark)/page.tsx
@@ -6,11 +6,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import StudyCard from '@/components/main/StudyCard'
-import Autoplay from 'embla-carousel-autoplay'
 import { dummyStackUrl, studyDummyData } from '@/lib/dummy'
 import { motion } from 'framer-motion'
 import { useInView } from 'react-intersection-observer'
-
+import AutoScroll from 'embla-carousel-auto-scroll'
 import {
   Carousel,
   CarouselItem,
@@ -22,8 +21,7 @@ import { FaAngleRight } from 'react-icons/fa6'
 
 export default function Home() {
   const [ref, inView] = useInView({ triggerOnce: true })
-
-  const plugin = useRef(Autoplay({ delay: 2500 }))
+  const plugin = useRef(AutoScroll({ playOnInit: true }))
   const mainIntroduceTextFirstLine = ['개발자', '를 꿈꾸는']
   const mainIntroduceTextSecondLine = ['모든 ', '학생', '들을 ', '위해서']
   const subIntroduceTextFirstLine = [
@@ -176,11 +174,13 @@ export default function Home() {
             </p>
             <div className="mt-8 flex h-[128px] w-full items-center">
               <Carousel
-                className="flex w-full items-center justify-between"
-                opts={{ align: 'start' }}
+                className="pointer-events-none flex w-full items-center justify-between"
+                opts={{
+                  align: 'start',
+                  loop: true
+                }}
                 plugins={[plugin.current]}
               >
-                <CarouselPrevious />
                 <CarouselContent>
                   {dummyStackUrl.map((item, index) => {
                     return (
@@ -202,7 +202,6 @@ export default function Home() {
                     )
                   })}
                 </CarouselContent>
-                <CarouselNext />
               </Carousel>
             </div>
           </div>
@@ -221,7 +220,7 @@ export default function Home() {
                 <Link href="/study">더보기</Link>
               </Button>
             </div>
-            <div className="mt-8 grid xl:grid-cols-4 gap-4 sm:gap-12 grid-cols-2 xl:mb-32">
+            <div className="mt-8 grid grid-cols-2 gap-4 sm:gap-12 xl:mb-32 xl:grid-cols-4">
               {studyDummyData.slice(0, 4).map((item, index) => {
                 return <StudyCard {...item} key={index} />
               })}

--- a/app/(main)/(dark)/page.tsx
+++ b/app/(main)/(dark)/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import StudyCard from '@/components/main/StudyCard'
 import Autoplay from 'embla-carousel-autoplay'
 import { dummyStackUrl, studyDummyData } from '@/lib/dummy'
-import { motion, useAnimation } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { useInView } from 'react-intersection-observer'
 
 import {
@@ -21,7 +21,6 @@ import {
 import { FaAngleRight } from 'react-icons/fa6'
 
 export default function Home() {
-  const controls = useAnimation()
   const [ref, inView] = useInView({ triggerOnce: true })
 
   const plugin = useRef(Autoplay({ delay: 2500 }))
@@ -132,7 +131,6 @@ export default function Home() {
           </motion.div>
           <div className="flex w-full justify-between font-semibold max-xl:flex-col">
             <motion.div
-              ref={ref}
               initial={{ opacity: 0, y: 100 }}
               animate={{ opacity: inView ? 1 : 0, y: inView ? 0 : 100 }}
               transition={{ duration: 1, ease: [0.6, -0.05, 0.01, 0.9] }}
@@ -143,7 +141,6 @@ export default function Home() {
               </p>
             </motion.div>
             <motion.div
-              ref={ref}
               initial={{ opacity: 0, y: 100 }}
               animate={{ opacity: inView ? 1 : 0, y: inView ? 0 : 100 }}
               transition={{
@@ -158,7 +155,6 @@ export default function Home() {
               </p>
             </motion.div>
             <motion.div
-              ref={ref}
               initial={{ opacity: 0, y: 100 }}
               animate={{ opacity: inView ? 1 : 0, y: inView ? 0 : 100 }}
               transition={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "dayjs": "^1.11.10",
+        "embla-carousel-auto-scroll": "^8.0.0",
         "embla-carousel-autoplay": "^8.0.0",
         "embla-carousel-react": "^8.0.0",
         "framer-motion": "^11.0.8",
@@ -2212,6 +2213,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.0.tgz",
       "integrity": "sha512-ecixcyqS6oKD2nh5Nj5MObcgoSILWNI/GtBxkidn5ytFaCCmwVHo2SecksaQZHcARMMpIR2dWOlSIdA1LkZFUA=="
+    },
+    "node_modules/embla-carousel-auto-scroll": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-auto-scroll/-/embla-carousel-auto-scroll-8.0.0.tgz",
+      "integrity": "sha512-+bG79hg/BhI4enRevR6fuQdrJevfu3gfNg/S+1kGszXHUJHOOwDQne/dXOnQ12+o74XvDD5t/LG45rAOplehhQ==",
+      "peerDependencies": {
+        "embla-carousel": "8.0.0"
+      }
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "dayjs": "^1.11.10",
+    "embla-carousel-auto-scroll": "^8.0.0",
     "embla-carousel-autoplay": "^8.0.0",
     "embla-carousel-react": "^8.0.0",
     "framer-motion": "^11.0.8",


### PR DESCRIPTION
### Description
<!-- Please explain what this PR is solving -->
1. main page에서 about 글자만 나와도 애니메이션 실행되게 변경
2. main page carousel에 autoscroll 적용
Closes #48 
<!-- Please close the issue (Closes #<issue number>) -->

### Additional context
<!-- Please specify the point to focus during code review -->

