### PR TITLE
fix: seperate studyList fetch from Home page to ExampleStudyList comp…

### DIFF
--- a/app/(main)/(dark)/page.tsx
+++ b/app/(main)/(dark)/page.tsx
@@ -10,12 +10,9 @@ import { Motion } from '@/components/common/MotionWrapper'
 import ExampleStudyList from '@/components/main/ExampleStudyList'
 import { MainCarousel } from '@/components/main/MainCarousel'
 import { Button } from '@/components/ui/button'
-import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { ROUTES } from '@/constants/routes'
 import { fadeIn } from '@/lib/animations'
-import { fetchData } from '@/lib/fetch'
 import mainPicture from '@/public/mainPicture.svg'
-import { Study } from '@/types'
 
 const mainIntroduceTextFirstLine: Array<string> = ['개발자', '를 꿈꾸는']
 const mainIntroduceTextSecondLine: Array<string> = ['모든 ', '학생', '들을 ', '위해서']
@@ -36,10 +33,7 @@ const aboutData: { description: string; number: number }[] = [
   }
 ]
 
-const Home = async (): Promise<React.JSX.Element> => {
-  const res = await fetchData(API_ENDPOINTS.STUDY.LIST)
-  const studyList: Study[] = res.data
-
+const Home = () => {
   const renderAnimatedText = (text: Array<string>) => {
     return text.map((item: string, index: number) => {
       if (item === '개발자' || item === '학생') {
@@ -174,7 +168,7 @@ const Home = async (): Promise<React.JSX.Element> => {
               </Button>
             </div>
             <Suspense fallback={<LoadingSpinner />}>
-              <ExampleStudyList studyList={studyList} />
+              <ExampleStudyList />
             </Suspense>
             <Button
               variant="outline"

--- a/components/main/ExampleStudyList.tsx
+++ b/components/main/ExampleStudyList.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link'
 
 import StudyCard from '@/components/common/StudyCard'
+import { API_ENDPOINTS } from '@/constants/apiEndpoint'
+import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
 
-interface ExampleStudyListProps {
-  studyList: Study[]
-}
-
-export default function ExampleStudyList({ studyList }: ExampleStudyListProps) {
+export const ExampleStudyList = async (): Promise<React.JSX.Element> => {
+  const res = await fetchData(API_ENDPOINTS.STUDY.LIST)
+  const studyList: Study[] = res.data
   const exampleStudies = studyList.slice(0, 4)
 
   return (
@@ -25,3 +25,5 @@ export default function ExampleStudyList({ studyList }: ExampleStudyListProps) {
     </div>
   )
 }
+
+export default ExampleStudyList


### PR DESCRIPTION
### Description
#112 (https://github.com/skku-comit/comit-website/issues/112#issue-2459128249)를 참고해주세요.
`studyList`를 fetch하는 로직을 `ExampleStudyList` 컴포넌트로 이전했습니다.

### Additional context
NextJS에 대한 제 부족한 부분이 적나라하게 드러나네요.
하루 갈아 넣었지만 잘 배웠습니다.