### PR TITLE
114 add study signup page

### DIFF
--- a/app/(main)/(light)/study/[id]/signup/page.tsx
+++ b/app/(main)/(light)/study/[id]/signup/page.tsx
@@ -1,8 +1,5 @@
-import Image from 'next/image'
-
 import SectionBanner from '@/components/common/SectionBanner'
-import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
+import StudySignupForm from '@/components/study/signup/StudySignupForm'
 import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
@@ -13,68 +10,16 @@ interface StudySignupProps {
   }
 }
 
-const Subheader = ({ children }: { children: string }) => {
-  return <h3 className="text-lg">{children}</h3>
-}
-
 const StudySignup = async ({ params }: StudySignupProps) => {
   const { id } = params
 
   const res = await fetchData(API_ENDPOINTS.STUDY.RETRIEVE(id))
   const study: Study = res.data
 
-  const duration = (startTime: string | null, endTime: string | null) => {
-    if (!startTime || !endTime) {
-      return '(시간 미정)'
-    }
-    return `${startTime.substring(0, 5)} ~ ${endTime.substring(0, 5)}`
-  }
-
   return (
     <>
       <SectionBanner title="스터디 참여 신청" />
-
-      <Subheader>1. 신청 스터디 확인</Subheader>
-      <div>
-        <Image src={study.imageSrc} alt="study image" width={300} height={300} />
-        <div>
-          <h4>{study.title}</h4>
-          <p>{study.mentor.name}</p>
-          <p>
-            {study.campus}
-            {study.day && ` | ${study.day}`}
-          </p>
-          <p>{duration(study.startTime, study.endTime)}</p>
-          <p>{study.level}</p>
-          <div className="flex justify-start gap-x-2">
-            {study.stack.map((s) => (
-              <Badge key={s} variant="secondary">
-                {s}
-              </Badge>
-            ))}
-          </div>
-
-          <div className="rounded-xl border p-2">
-            <p className="whitespace-pre-line break-keep" dangerouslySetInnerHTML={{ __html: study.description }} />
-          </div>
-        </div>
-
-        <div>
-          <p>* 스터디 장소, 날짜, 시간을 다시 한번 확인해주세요.</p>
-          <p>* 다중 스터디 신청은 가능합니다 (여러 스터디 참여 가능)</p>
-        </div>
-      </div>
-
-      <Subheader>3. 지원동기 작성</Subheader>
-      <span>300자 이내</span>
-      <div>
-        <p>* 자신의 열정 및 스터디 참여 의지를 어필해주세요</p>
-        <p>* 지원동기는 스터디 신청 기간동안 자유롭게 수정 가능합니다</p>
-
-        <div className="rounded-xl border p-2">
-          <Input />
-        </div>
-      </div>
+      <StudySignupForm study={study} />
     </>
   )
 }

--- a/app/(main)/(light)/study/[id]/signup/page.tsx
+++ b/app/(main)/(light)/study/[id]/signup/page.tsx
@@ -1,0 +1,20 @@
+import { API_ENDPOINTS } from '@/constants/apiEndpoint'
+import { fetchData } from '@/lib/fetch'
+import { Study } from '@/types'
+
+interface StudySignupProps {
+  params: {
+    slug: string
+  }
+}
+
+const StudySignup = async ({ params }: StudySignupProps) => {
+  const { slug } = params
+
+  const res = await fetchData(API_ENDPOINTS.STUDY.RETRIEVE(slug))
+  const studyData: Study = res.data
+
+  return <>{studyData}</>
+}
+
+export default StudySignup

--- a/app/(main)/(light)/study/[id]/signup/page.tsx
+++ b/app/(main)/(light)/study/[id]/signup/page.tsx
@@ -1,20 +1,82 @@
+import Image from 'next/image'
+
+import SectionBanner from '@/components/common/SectionBanner'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
 import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
 
 interface StudySignupProps {
   params: {
-    slug: string
+    id: string
   }
 }
 
+const Subheader = ({ children }: { children: string }) => {
+  return <h3 className="text-lg">{children}</h3>
+}
+
 const StudySignup = async ({ params }: StudySignupProps) => {
-  const { slug } = params
+  const { id } = params
 
-  const res = await fetchData(API_ENDPOINTS.STUDY.RETRIEVE(slug))
-  const studyData: Study = res.data
+  const res = await fetchData(API_ENDPOINTS.STUDY.RETRIEVE(id))
+  const study: Study = res.data
 
-  return <>{studyData}</>
+  const duration = (startTime: string | null, endTime: string | null) => {
+    if (!startTime || !endTime) {
+      return '(시간 미정)'
+    }
+    return `${startTime.substring(0, 5)} ~ ${endTime.substring(0, 5)}`
+  }
+
+  return (
+    <>
+      <SectionBanner title="스터디 참여 신청" />
+
+      <Subheader>1. 신청 스터디 확인</Subheader>
+      <div>
+        <Image src={study.imageSrc} alt="study image" width={300} height={300} />
+        <div>
+          <h4>{study.title}</h4>
+          <p>{study.mentor.name}</p>
+          <p>
+            {study.campus}
+            {study.day && ` | ${study.day}`}
+          </p>
+          <p>{duration(study.startTime, study.endTime)}</p>
+          <p>{study.level}</p>
+          <div className="flex justify-start gap-x-2">
+            {study.stack.map((s) => (
+              <Badge key={s} variant="secondary">
+                {s}
+              </Badge>
+            ))}
+          </div>
+
+          <div className="rounded-xl border p-2">
+            <p className="whitespace-pre-line break-keep" dangerouslySetInnerHTML={{ __html: study.description }} />
+          </div>
+        </div>
+
+        <div>
+          <p>* 스터디 장소, 날짜, 시간을 다시 한번 확인해주세요.</p>
+          <p>* 다중 스터디 신청은 가능합니다 (여러 스터디 참여 가능)</p>
+        </div>
+      </div>
+
+      <Subheader>3. 지원동기 작성</Subheader>
+      <span>300자 이내</span>
+      <div>
+        <p>* 자신의 열정 및 스터디 참여 의지를 어필해주세요</p>
+        <p>* 지원동기는 스터디 신청 기간동안 자유롭게 수정 가능합니다</p>
+
+        <div className="rounded-xl border p-2">
+          <Input />
+        </div>
+      </div>
+    </>
+  )
 }
 
 export default StudySignup

--- a/app/(main)/(light)/study/[id]/signup/page.tsx
+++ b/app/(main)/(light)/study/[id]/signup/page.tsx
@@ -19,7 +19,9 @@ const StudySignup = async ({ params }: StudySignupProps) => {
   return (
     <>
       <SectionBanner title="스터디 참여 신청" />
-      <StudySignupForm study={study} />
+      <div className="max-w-[1280px]">
+        <StudySignupForm study={study} />
+      </div>
     </>
   )
 }

--- a/app/api/errors/customErrors.ts
+++ b/app/api/errors/customErrors.ts
@@ -7,3 +7,10 @@ export const EnrollmentPeriodExceeded: ServerError = {
   title: '수강신청 기간 초과',
   detail: '현재는 수강신청 가능한 기간이 아닙니다. 관리자에게 문의하세요.'
 }
+
+export const AlreadySignedup: ServerError = {
+  errorType: '/study-signup/alreadySignedup',
+  status: HttpStatusCode.BadRequest,
+  title: '중복된 수강신청',
+  detail: '이미 신청되었습니다'
+}

--- a/app/api/studies/[id]/route.ts
+++ b/app/api/studies/[id]/route.ts
@@ -1,6 +1,83 @@
-import { api } from '../../utils/factory'
+import { NextRequest } from 'next/server'
 
-const GET = api.RetrieveFactory('study')
+import { supabase } from '@/lib/supabase/client'
+
+import { api } from '../../utils/factory'
+import { HttpStatusCode } from '../../utils/httpConsts'
+import { getNextResponse, ServerResponse } from '../../utils/response'
+
+const GET = async (req: NextRequest) => {
+  try {
+    const { pathname } = req.nextUrl
+    const id = pathname.split('/').pop()
+    if (!id) {
+      const customErrorResponse: ServerResponse = {
+        error: {
+          errorType: `/study-retrieve`,
+          status: HttpStatusCode.BadRequest,
+          title: 'No id was given',
+          detail: 'No id was given. Please specify the id.',
+          instance: `/study`
+        },
+        data: null,
+        count: null,
+        status: HttpStatusCode.BadRequest,
+        statusText: 'Bad Request'
+      }
+      return getNextResponse(customErrorResponse)
+    }
+
+    const res = await supabase.from('study').select('*, mentor ( * )').eq('id', id).single()
+
+    if (res.error) {
+      if (res.status === HttpStatusCode.NotAcceptable) {
+        const customErrorResponse: ServerResponse = {
+          error: {
+            errorType: `/study-retrieve`,
+            status: HttpStatusCode.NotFound,
+            title: res.error.message,
+            detail: res.error.details,
+            instance: `/study/${id}`
+          },
+          data: res.data,
+          count: res.data,
+          status: HttpStatusCode.NotFound,
+          statusText: res.statusText
+        }
+        return getNextResponse(customErrorResponse)
+      }
+
+      const customErrorResponse: ServerResponse = {
+        error: {
+          errorType: `/study-retrieve`,
+          status: res.status,
+          title: res.error.message,
+          detail: res.error.details,
+          instance: `/study/${id}`
+        },
+        data: res.data,
+        count: res.data,
+        status: res.status,
+        statusText: res.statusText
+      }
+      return getNextResponse(customErrorResponse)
+    }
+    return getNextResponse(res)
+  } catch (error) {
+    return getNextResponse({
+      error: {
+        errorType: `/study-retrieve`,
+        status: HttpStatusCode.InternalServerError,
+        title: 'Internal Server Error',
+        instance: `/study`
+      },
+      data: null,
+      count: null,
+      status: HttpStatusCode.InternalServerError,
+      statusText: 'Internal Server Error'
+    })
+  }
+}
 const PUT = api.PutFactory('study')
 const PATCH = api.PatchFactory('study')
 const DELETE = api.DeleteFactory('study')

--- a/app/api/studies/[id]/signup/route.ts
+++ b/app/api/studies/[id]/signup/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server'
+
+import { HttpStatusCode } from '@/app/api/utils/httpConsts'
+import { getNextResponse } from '@/app/api/utils/response'
+
+const POST = async (req: NextRequest) => {
+  const data = await req.json()
+
+  return getNextResponse({
+    error: null,
+    data: null,
+    count: null,
+    status: HttpStatusCode.NotImplemented,
+    statusText: `Server got requst: ${data}. But this endpoint is not implemented`
+  })
+}
+export { POST }

--- a/app/api/studies/[id]/signup/route.ts
+++ b/app/api/studies/[id]/signup/route.ts
@@ -11,9 +11,11 @@ const POST = async (req: NextRequest) => {
   try {
     const data: StudySignupRequest = await req.json()
     type InsertType = Database['public']['Tables']['study-participants']['Insert']
+    // TODO: user id는 헤더에서 받기
+    const TEST_USER_ID = 'b5851320-d374-4763-a7d5-70427602c19b' // 손장수
     const inputData: InsertType = {
       study_id: data.study_id,
-      profile_id: data.user_id,
+      profile_id: TEST_USER_ID,
       applicationMotiv: data.applicationMotiv
     }
 

--- a/app/api/studies/[id]/signup/route.ts
+++ b/app/api/studies/[id]/signup/route.ts
@@ -11,7 +11,7 @@ const POST = async (req: NextRequest) => {
     data: null,
     count: null,
     status: HttpStatusCode.NotImplemented,
-    statusText: `Server got requst: ${data}. But this endpoint is not implemented`
+    statusText: `Server got requst: ${JSON.stringify(data)}. But this endpoint is not implemented`
   })
 }
 export { POST }

--- a/app/api/utils/httpConsts.ts
+++ b/app/api/utils/httpConsts.ts
@@ -19,6 +19,7 @@ export enum HttpStatusCode {
   NotFound = 404,
   MethodNotAllowed = 405,
   NotAcceptable = 406,
+  Conflict = 409,
   IamAteapot = 418,
   InternalServerError = 500,
   NotImplemented = 501

--- a/components/common/Header/index.tsx
+++ b/components/common/Header/index.tsx
@@ -28,11 +28,11 @@ const DrawerItem = ({ route, icon }: { route: Route; icon: React.ReactNode }) =>
 }
 
 const Header = ({ isDarkMode }: { isDarkMode: boolean }) => {
-  const NAVLINK_ROUTES = [ROUTES.ABOUT, ROUTES.STUDY, ROUTES.CLUBROOM]
+  const NAVLINK_ROUTES = [ROUTES.ABOUT, ROUTES.STUDY.index, ROUTES.CLUBROOM]
   const DRAWER_ITEMS_WITH_ICON = [
     { route: ROUTES.HOME, icon: <IoHomeOutline size={27} /> },
     { route: ROUTES.ABOUT, icon: <IoMdInformationCircleOutline size={27} /> },
-    { route: ROUTES.STUDY, icon: <IoLaptopOutline size={27} /> },
+    { route: ROUTES.STUDY.index, icon: <IoLaptopOutline size={27} /> },
     { route: ROUTES.CLUBROOM, icon: <BsDoorOpen size={27} /> },
     { route: ROUTES.LOGIN, icon: <MdLogin size={27} /> },
     { route: ROUTES.SIGNUP, icon: <FaRegPenToSquare size={24} /> }

--- a/components/common/LoadingSpinner.tsx
+++ b/components/common/LoadingSpinner.tsx
@@ -1,5 +1,9 @@
 import { AiOutlineLoading } from 'react-icons/ai'
 
-export default function LoadingSpinner() {
-  return <AiOutlineLoading className="animate-spin" size={84} />
+interface LoadingSpinnerProps {
+  size?: number
+}
+
+export default function LoadingSpinner({ size = 84 }: LoadingSpinnerProps) {
+  return <AiOutlineLoading className="animate-spin" size={size} />
 }

--- a/components/common/SectionBanner.tsx
+++ b/components/common/SectionBanner.tsx
@@ -16,9 +16,9 @@ export default function SectionBanner({
   descriptionClassName
 }: SectionBannerProps) {
   return (
-    <div className={cn('flex h-48 w-screen flex-col items-center justify-center gap-5 sm:h-56', className)}>
-      <p className={cn('text-5xl font-semibold sm:text-5xl', titleClassName)}>{title}</p>
-      {description && <p className={cn('text-lg font-bold sm:text-xl', descriptionClassName)}>{description}</p>}
+    <div className={cn('flex h-36 w-screen flex-col items-center justify-center gap-5 lg:h-56', className)}>
+      <p className={cn('text-3xl font-semibold lg:text-5xl', titleClassName)}>{title}</p>
+      {description && <p className={cn('text-lg font-bold lg:text-xl', descriptionClassName)}>{description}</p>}
     </div>
   )
 }

--- a/components/common/SectionBanner.tsx
+++ b/components/common/SectionBanner.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils'
 
 interface SectionBannerProps {
   title: string
-  description: string
+  description?: string
   className?: string
   titleClassName?: string
   descriptionClassName?: string
@@ -18,7 +18,7 @@ export default function SectionBanner({
   return (
     <div className={cn('flex h-48 w-screen flex-col items-center justify-center gap-5 sm:h-56', className)}>
       <p className={cn('text-5xl font-semibold sm:text-5xl', titleClassName)}>{title}</p>
-      <p className={cn('text-lg font-bold sm:text-xl', descriptionClassName)}>{description}</p>
+      {description && <p className={cn('text-lg font-bold sm:text-xl', descriptionClassName)}>{description}</p>}
     </div>
   )
 }

--- a/components/study/StudyList.tsx
+++ b/components/study/StudyList.tsx
@@ -4,7 +4,7 @@ import { MdOutlineSignalCellularAlt } from 'react-icons/md'
 import { RiStackOverflowLine } from 'react-icons/ri'
 
 import StudyCard from '@/components/common/StudyCard'
-import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
@@ -26,7 +26,7 @@ const StudyList = async () => {
             />
           </DialogTrigger>
           <DialogContent className="w-[324px] rounded-xl p-6 sm:w-[480px] sm:p-8">
-            <div className="break-words text-2xl font-bold">{study.title}</div>
+            <DialogTitle className="break-words text-2xl font-bold">{study.title}</DialogTitle>
             {!study.day ? null : !study.startTime || !study.endTime ? (
               <div className="flex gap-3 break-words text-lg text-gray-600">
                 {study.day}요일 <span className="text-base text-red-500">(시간 미정)</span>

--- a/components/study/StudyList.tsx
+++ b/components/study/StudyList.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { FaSchoolFlag } from 'react-icons/fa6'
 import { IoPersonSharp } from 'react-icons/io5'
 import { MdOutlineSignalCellularAlt } from 'react-icons/md'
@@ -6,8 +7,11 @@ import { RiStackOverflowLine } from 'react-icons/ri'
 import StudyCard from '@/components/common/StudyCard'
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { API_ENDPOINTS } from '@/constants/apiEndpoint'
+import { ROUTES } from '@/constants/routes'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
+
+import { Button } from '../ui/button'
 
 const StudyList = async () => {
   const res = await fetchData(API_ENDPOINTS.STUDY.LIST)
@@ -57,6 +61,12 @@ const StudyList = async () => {
                 {study.stack.join(', ')}
               </div>
               <div className="whitespace-pre-line break-keep" dangerouslySetInnerHTML={{ __html: study.description }} />
+            </div>
+
+            <div className="flex justify-end">
+              <Button asChild>
+                <Link href={ROUTES.STUDY.SIGNUP(study.id).url}>신청하기</Link>
+              </Button>
             </div>
           </DialogContent>
         </Dialog>

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -101,7 +101,7 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
                 />
               </div>
               {/* 스터디 기본 정보 */}
-              <div className="space-y-1 rounded-lg bg-slate-100 p-5 lg:space-y-3 lg:bg-transparent lg:p-0">
+              <div className="space-y-1 rounded-lg bg-slate-100 p-5 md:bg-transparent md:p-0 lg:space-y-3">
                 <h4 className="mb-3 text-xl font-bold">{study.title}</h4>
 
                 <HoverCard>

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -15,12 +15,17 @@ import LoadingSpinner from '@/components/common/LoadingSpinner'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
 
 export interface StudySignupRequest {
+  username: string
+  studentId: number
+  github: string
   study_id: string
   applicationMotiv: string
 }
@@ -30,6 +35,9 @@ const Subheader = ({ children }: { children: React.ReactNode }) => {
 }
 
 interface IStudySignupForm {
+  username: string
+  studentId: number
+  github: string
   applicationMotiv: string
 }
 
@@ -64,11 +72,19 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
     register,
     formState: { errors, isSubmitting }
   } = useForm<IStudySignupForm>({
-    resolver: zodResolver(schema)
+    resolver: zodResolver(schema),
+    defaultValues: {
+      username: '손장수',
+      studentId: 2019313647,
+      github: 'github.com/skku-comit/comit-website'
+    }
   })
 
   const onValid = async (formData: IStudySignupForm) => {
     const requestBody: StudySignupRequest = {
+      username: formData.username,
+      studentId: formData.studentId,
+      github: formData.github,
       study_id: study.id,
       applicationMotiv: formData.applicationMotiv
     }
@@ -152,6 +168,48 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
           <div className="text-sm lg:space-y-1">
             <p>* 스터디 장소, 날짜, 시간을 다시 한번 확인해주세요.</p>
             <p>* 다중 스터디 신청은 가능합니다 (여러 스터디 참여 가능)</p>
+          </div>
+        </div>
+
+        <div className="py-10">
+          <Subheader>2. 개인정보 확인</Subheader>
+          {/* 참고 사항 */}
+          <div className="text-sm lg:space-y-1">
+            <p>* 아래 정보는 스터디장에게 제공됩니다</p>
+            <p>* Github 주소는 필수 정보가 아닙니다</p>
+          </div>
+
+          {/* 이름, 학번, Github 확인 */}
+          <div className="mt-5 flex flex-col gap-x-16 lg:flex-row">
+            {/* 이름 */}
+            <div className="flex items-center lg:block">
+              <Label className="me-3 text-xl font-bold lg:me-0">이름{'username' && ' *'}</Label>
+              <Input
+                disabled
+                {...register('username')}
+                className="text-md mt-2 h-10 w-40 rounded-xl bg-secondary text-center lg:h-14 lg:w-60 lg:text-lg"
+              />
+              {errors.username && <p className="text-destructive">{errors.username.message}</p>}
+            </div>
+            {/* 학번 */}
+            <div className="flex items-center lg:block">
+              <Label className="me-3 text-xl font-bold lg:me-0">학번{'studentId' && ' *'}</Label>
+              <Input
+                disabled
+                {...register('studentId')}
+                className="text-md mt-2 h-10 w-40 rounded-xl bg-secondary text-center lg:h-14 lg:w-60 lg:text-lg"
+              />
+              {errors.studentId && <p className="text-destructive">{errors.studentId.message}</p>}
+            </div>
+            {/* Github */}
+            <div className="flex items-center lg:block">
+              <Label className="me-3 text-xl font-bold lg:me-0">Github{!'github' && ' *'}</Label>
+              <Input
+                {...register('github')}
+                className="text-md mt-2 h-10 w-72 rounded-xl bg-secondary text-center lg:h-14 lg:w-96 lg:text-lg"
+              />
+              {errors.github && <p className="text-destructive">{errors.github.message}</p>}
+            </div>
           </div>
         </div>
 

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -12,16 +12,22 @@ import { API_ENDPOINTS } from '@/constants/apiEndpoint'
 import { fetchData } from '@/lib/fetch'
 import { Study } from '@/types'
 
+export interface StudySignupRequest {
+  study_id: string
+  user_id: string
+  applicationMotiv: string
+}
+
 const Subheader = ({ children }: { children: string }) => {
   return <h3 className="text-lg">{children}</h3>
 }
 
 interface IStudySignupForm {
-  motiv: string
+  applicationMotiv: string
 }
 
 const schema = z.object({
-  motiv: z.string().min(1, {
+  applicationMotiv: z.string().min(1, {
     message: '지원 동기를 입력해주세요'
   })
 })
@@ -47,9 +53,14 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
     resolver: zodResolver(schema)
   })
 
-  const onValid = async (data: IStudySignupForm) => {
-    const jsonData = JSON.stringify(data)
-    console.log(jsonData)
+  const onValid = async (formData: IStudySignupForm) => {
+    const TEST_USER_ID = 'b5851320-d374-4763-a7d5-70427602c19b' // 손장수
+    const requestBody: StudySignupRequest = {
+      study_id: study.id,
+      user_id: TEST_USER_ID,
+      applicationMotiv: formData.applicationMotiv
+    }
+    const jsonData = JSON.stringify(requestBody)
     const res = await fetchData(API_ENDPOINTS.STUDY.SIGNUP(study.id), {
       headers: {
         'Content-Type': 'application/json'
@@ -99,8 +110,8 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
         <p>* 지원동기는 스터디 신청 기간동안 자유롭게 수정 가능합니다</p>
 
         <div className="rounded-xl border p-2">
-          <Input id="motiv" {...register('motiv')} placeholder="지원 동기를 입력해주세요" />
-          {errors.motiv && <p className="text-destructive">{errors.motiv.message}</p>}
+          <Input id="applicationMotiv" {...register('applicationMotiv')} placeholder="지원 동기를 입력해주세요" />
+          {errors.applicationMotiv && <p className="text-destructive">{errors.applicationMotiv.message}</p>}
         </div>
       </div>
 

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import Image from 'next/image'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { API_ENDPOINTS } from '@/constants/apiEndpoint'
+import { fetchData } from '@/lib/fetch'
+import { Study } from '@/types'
+
+const Subheader = ({ children }: { children: string }) => {
+  return <h3 className="text-lg">{children}</h3>
+}
+
+interface IStudySignupForm {
+  motiv: string
+}
+
+const schema = z.object({
+  motiv: z.string().min(1, {
+    message: '지원 동기를 입력해주세요'
+  })
+})
+
+interface StudySignupFormProps {
+  study: Study
+}
+
+const StudySignupForm = ({ study }: StudySignupFormProps) => {
+  const duration = (startTime: string | null, endTime: string | null) => {
+    if (!startTime || !endTime) {
+      return '(시간 미정)'
+    }
+    return `${startTime.substring(0, 5)} ~ ${endTime.substring(0, 5)}`
+  }
+
+  // Form related logics
+  const {
+    handleSubmit,
+    register,
+    formState: { errors }
+  } = useForm<IStudySignupForm>({
+    resolver: zodResolver(schema)
+  })
+
+  const onValid = async (data: IStudySignupForm) => {
+    const jsonData = JSON.stringify(data)
+    console.log(jsonData)
+    const res = await fetchData(API_ENDPOINTS.STUDY.SIGNUP(study.id), {
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: jsonData
+    })
+    console.log(res)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onValid)}>
+      <Subheader>1. 신청 스터디 확인</Subheader>
+      <div>
+        <Image src={study.imageSrc} alt="study image" width={300} height={300} />
+        <div>
+          <h4>{study.title}</h4>
+          <p>{study.mentor.name}</p>
+          <p>
+            {study.campus}
+            {study.day && ` | ${study.day}`}
+          </p>
+          <p>{duration(study.startTime, study.endTime)}</p>
+          <p>{study.level}</p>
+          <div className="flex justify-start gap-x-2">
+            {study.stack.map((s) => (
+              <Badge key={s} variant="secondary">
+                {s}
+              </Badge>
+            ))}
+          </div>
+
+          <div className="rounded-xl border p-2">
+            <p className="whitespace-pre-line break-keep" dangerouslySetInnerHTML={{ __html: study.description }} />
+          </div>
+        </div>
+
+        <div>
+          <p>* 스터디 장소, 날짜, 시간을 다시 한번 확인해주세요.</p>
+          <p>* 다중 스터디 신청은 가능합니다 (여러 스터디 참여 가능)</p>
+        </div>
+      </div>
+
+      <Subheader>3. 지원동기 작성</Subheader>
+      <span>300자 이내</span>
+      <div>
+        <p>* 자신의 열정 및 스터디 참여 의지를 어필해주세요</p>
+        <p>* 지원동기는 스터디 신청 기간동안 자유롭게 수정 가능합니다</p>
+
+        <div className="rounded-xl border p-2">
+          <Input id="motiv" {...register('motiv')} placeholder="지원 동기를 입력해주세요" />
+          {errors.motiv && <p className="text-destructive">{errors.motiv.message}</p>}
+        </div>
+      </div>
+
+      <Button type="submit">제출</Button>
+    </form>
+  )
+}
+
+export default StudySignupForm

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import Image from 'next/image'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -17,7 +17,6 @@ import { Study } from '@/types'
 
 export interface StudySignupRequest {
   study_id: string
-  user_id: string
   applicationMotiv: string
 }
 
@@ -38,6 +37,15 @@ interface StudySignupFormProps {
 }
 
 const StudySignupForm = ({ study }: StudySignupFormProps) => {
+  // TODO: 신청 취소 기능 추가
+  // TODO: 스터디 신청 정규화
+  // study-participants 이외에도 studyEnrollment라는 다른 테이블 만들기 -> 신청 한것과 실제 스터디 진행 인원 분리
+  // StudyEnrollment 엔티티 추가 및 CRUD API 엔드포인트 추가
+  // StudyEnrollment에는 createdAt, editedAt 추가해서 마지막으로 수정한 날짜도 UI에서 확인 가능하게 하기
+  useEffect(() => {
+    // TODO: 신청서 데이터 가져와서 채워 넣기
+  }, [])
+
   const duration = (startTime: string | null, endTime: string | null) => {
     if (!startTime || !endTime) {
       return '(시간 미정)'
@@ -55,10 +63,8 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
   })
 
   const onValid = async (formData: IStudySignupForm) => {
-    const TEST_USER_ID = 'b5851320-d374-4763-a7d5-70427602c19b' // 손장수
     const requestBody: StudySignupRequest = {
       study_id: study.id,
-      user_id: TEST_USER_ID,
       applicationMotiv: formData.applicationMotiv
     }
     const jsonData = JSON.stringify(requestBody)

--- a/components/study/signup/StudySignupForm.tsx
+++ b/components/study/signup/StudySignupForm.tsx
@@ -4,6 +4,11 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import Image from 'next/image'
 import React, { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
+import { FaSchoolFlag } from 'react-icons/fa6'
+import { IoPersonSharp } from 'react-icons/io5'
+import { IoTime } from 'react-icons/io5'
+import { MdOutlineSignalCellularAlt } from 'react-icons/md'
+import { RiStackOverflowLine } from 'react-icons/ri'
 import { z } from 'zod'
 
 import LoadingSpinner from '@/components/common/LoadingSpinner'
@@ -96,25 +101,36 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
                 />
               </div>
               {/* 스터디 기본 정보 */}
-              <div className="space-y-1 lg:space-y-3">
-                <h4 className="text-xl font-bold">{study.title}</h4>
+              <div className="space-y-1 rounded-lg bg-slate-100 p-5 lg:space-y-3 lg:bg-transparent lg:p-0">
+                <h4 className="mb-3 text-xl font-bold">{study.title}</h4>
+
                 <HoverCard>
                   <HoverCardTrigger>
-                    <p className="underline-offset-2 hover:underline">@{study.mentor.name}</p>
+                    <p className="flex items-center gap-2 underline-offset-2 hover:underline">
+                      <IoPersonSharp />@{study.mentor.name}
+                    </p>
                   </HoverCardTrigger>
                   <HoverCardContent>
                     {/* TODO: 스터디장 정보 기입 */}
-                    {/* {study.mentor.bio} */}
+                    Not Implemented
                   </HoverCardContent>
                 </HoverCard>
-                <p>
+                <p className="flex items-center gap-2">
+                  <FaSchoolFlag />
                   {study.campus}
                   {study.day && ` | ${study.day}`}
                 </p>
-                <p>{duration(study.startTime, study.endTime)}</p>
-                <p>{study.level}</p>
+                <p className="flex items-center gap-2">
+                  <IoTime />
+                  {duration(study.startTime, study.endTime)}
+                </p>
+                <p className="flex items-center gap-2">
+                  <MdOutlineSignalCellularAlt />
+                  {study.level}
+                </p>
                 <div className="overflow-auto">
                   <div className="flex justify-start gap-x-2">
+                    <RiStackOverflowLine />
                     {study.stack.map((s) => (
                       <Badge key={s} variant="secondary" className="text-xs">
                         {s}
@@ -126,13 +142,9 @@ const StudySignupForm = ({ study }: StudySignupFormProps) => {
             </div>
 
             {/* 스터디 상세 설명 */}
-            <div className="col-span-12 lg:col-span-6">
-              <div className="lg:rounded-lg lg:border">
-                <p
-                  className="whitespace-pre-line break-all p-1 lg:p-3"
-                  dangerouslySetInnerHTML={{ __html: study.description }}
-                />
-              </div>
+            <div className="col-span-12 mb-5 lg:col-span-6 lg:mb-0">
+              <h4 className="mb-2 text-lg font-extrabold">스터디 설명</h4>
+              <p className="whitespace-pre-line break-all" dangerouslySetInnerHTML={{ __html: study.description }} />
             </div>
           </div>
 

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardContent,HoverCardTrigger }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const labelVariants = cva('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70')
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/constants/apiEndpoint.ts
+++ b/constants/apiEndpoint.ts
@@ -16,6 +16,8 @@ interface StudyRoutes {
   LIST: ApiEndpoint
   UPDATE: (id: string) => ApiEndpoint
   DELETE: (id: string) => ApiEndpoint
+
+  SIGNUP: (id: string) => ApiEndpoint
 }
 
 interface MemberRoutes {
@@ -26,18 +28,20 @@ interface MemberRoutes {
   DELETE: (id: string) => ApiEndpoint
 }
 
-interface Routes {
+interface ApiEndpoints {
   STUDY: StudyRoutes
   MEMBER: MemberRoutes
 }
 
-export const API_ENDPOINTS: Routes = {
+export const API_ENDPOINTS: ApiEndpoints = {
   STUDY: {
     CREATE: { url: `${baseURL}/${API_PREFIX}/studies`, method: 'POST' },
     RETRIEVE: (id: string) => ({ url: `${baseURL}/${API_PREFIX}/studies/${id}`, method: 'GET' }),
     LIST: { url: `${baseURL}/${API_PREFIX}/studies`, method: 'GET' },
     UPDATE: (id: string) => ({ url: `${baseURL}/${API_PREFIX}/studies/${id}`, method: 'PUT' }),
-    DELETE: (id: string) => ({ url: `${baseURL}/${API_PREFIX}/studies/${id}`, method: 'DELETE' })
+    DELETE: (id: string) => ({ url: `${baseURL}/${API_PREFIX}/studies/${id}`, method: 'DELETE' }),
+
+    SIGNUP: (id: string) => ({ url: `${baseURL}/${API_PREFIX}/studies/${id}/signup`, method: 'POST' })
   },
   MEMBER: {
     CREATE: { url: `${baseURL}/${API_PREFIX}/users`, method: 'POST' },

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -7,8 +7,21 @@ export interface Route {
   name: string
   url: string
 }
+interface StudyRoutes {
+  index: Route
+  SIGNUP: (id: string) => Route
+}
 
-export const ROUTES: { [key: string]: Route } = {
+interface Routes {
+  HOME: Route
+  ABOUT: Route
+  STUDY: StudyRoutes
+  CLUBROOM: Route
+  LOGIN: Route
+  SIGNUP: Route
+}
+
+export const ROUTES: Routes = {
   HOME: {
     name: 'Home',
     url: '/'
@@ -18,8 +31,14 @@ export const ROUTES: { [key: string]: Route } = {
     url: '/about'
   },
   STUDY: {
-    name: 'Study',
-    url: '/study'
+    index: {
+      name: 'Study',
+      url: '/study'
+    },
+    SIGNUP: (id: string) => ({
+      name: 'Study Signup',
+      url: `/study/${id}/signup`
+    })
   },
   CLUBROOM: {
     name: 'Clubroom',

--- a/database.types.ts
+++ b/database.types.ts
@@ -103,14 +103,17 @@ export type Database = {
       }
       'study-participants': {
         Row: {
+          applicationMotiv: string
           profile_id: string
           study_id: string
         }
         Insert: {
+          applicationMotiv: string
           profile_id: string
           study_id: string
         }
         Update: {
+          applicationMotiv?: string
           profile_id?: string
           study_id?: string
         }

--- a/database.types.ts
+++ b/database.types.ts
@@ -45,39 +45,6 @@ export type Database = {
         }
         Relationships: []
       }
-      'profile-study': {
-        Row: {
-          id: number
-          profile: string
-          study: string
-        }
-        Insert: {
-          id?: number
-          profile: string
-          study: string
-        }
-        Update: {
-          id?: number
-          profile?: string
-          study?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'profile-study_profile_fkey'
-            columns: ['profile']
-            isOneToOne: false
-            referencedRelation: 'profile'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'profile-study_study_fkey'
-            columns: ['study']
-            isOneToOne: false
-            referencedRelation: 'study'
-            referencedColumns: ['id']
-          }
-        ]
-      }
       study: {
         Row: {
           campus: string
@@ -86,7 +53,7 @@ export type Database = {
           description: string
           endTime: string | null
           id: string
-          imageSrc: string | null
+          imageSrc: string
           isRecruiting: boolean
           level: string
           mentor: string | null
@@ -101,7 +68,7 @@ export type Database = {
           description: string
           endTime?: string | null
           id?: string
-          imageSrc?: string | null
+          imageSrc: string
           isRecruiting?: boolean
           level: string
           mentor?: string | null
@@ -116,7 +83,7 @@ export type Database = {
           description?: string
           endTime?: string | null
           id?: string
-          imageSrc?: string | null
+          imageSrc?: string
           isRecruiting?: boolean
           level?: string
           mentor?: string | null
@@ -130,6 +97,36 @@ export type Database = {
             columns: ['mentor']
             isOneToOne: false
             referencedRelation: 'profile'
+            referencedColumns: ['id']
+          }
+        ]
+      }
+      'study-participants': {
+        Row: {
+          profile_id: string
+          study_id: string
+        }
+        Insert: {
+          profile_id: string
+          study_id: string
+        }
+        Update: {
+          profile_id?: string
+          study_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'profile-study_profile_fkey'
+            columns: ['profile_id']
+            isOneToOne: false
+            referencedRelation: 'profile'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'profile-study_study_fkey'
+            columns: ['study_id']
+            isOneToOne: false
+            referencedRelation: 'study'
             referencedColumns: ['id']
           }
         ]

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -10,7 +10,7 @@ export async function fetchData(route: ApiEndpoint, init?: RequestInit): Promise
 
   const res = await fetch(route.url, requestInit)
   if (!res.ok) {
-    throw new FetchError(`Failed to fetch ${route.url} (${route.method})`)
+    throw new FetchError(`Failed to fetch ${route.url} (${route.method})\n${res.status}: ${res.statusText}`)
   }
   return res.json()
 }

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -2,11 +2,15 @@ import { ServerResponse } from '@/app/api/utils/response'
 import { ApiEndpoint } from '@/constants/apiEndpoint'
 import { FetchError } from '@/errors'
 
-export async function fetchData(route: ApiEndpoint): Promise<ServerResponse> {
-  const res = await fetch(route.url, { method: route.method })
-  if (!res.ok) {
-    throw new FetchError(`Failed to Fetch ${route.url} (${route.method})`)
+export async function fetchData(route: ApiEndpoint, init?: RequestInit): Promise<ServerResponse> {
+  const requestInit: RequestInit = {
+    method: route.method,
+    ...init
   }
 
+  const res = await fetch(route.url, requestInit)
+  if (!res.ok) {
+    throw new FetchError(`Failed to fetch ${route.url} (${route.method})`)
+  }
   return res.json()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-slot": "^1.0.2",
@@ -704,6 +705,36 @@
         "@radix-ui/react-compose-refs": "1.1.0",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.1.tgz",
+      "integrity": "sha512-IwzAOP97hQpDADYVKrEEHUH/b2LA+9MgB0LgdmnbFO2u/3M5hmEofjjr2M6CyzUblaAqJdFm6B7oFtU72DPXrA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-hover-card": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-slot": "^1.0.2",

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,4 +20,5 @@ export type Study = BaseStudy & {
   campus: Campus
   day: Day | null
   level: Level
+  mentor: User
 }


### PR DESCRIPTION
### Description
# Front
## `StudyCard`에 신청 버튼 추가
![image](https://github.com/user-attachments/assets/eef124f6-ec41-4eac-a6c9-b72d6bcee3cf)
## 스터디 참여 신청 페이지 추가(반응형)
-lg 이상
![image](https://github.com/user-attachments/assets/7967a707-82be-4ea6-9330-3e089190bd74)
-md ~ lg
![image](https://github.com/user-attachments/assets/a45484ee-9f16-4dee-ab63-11adfa6d8252)
-md 미만
![image](https://github.com/user-attachments/assets/f9f32055-d22c-417a-875b-8f57281b0e1b)

# Backend(Backup)
## `Study Retrieve` API 구현
`Factory CRUD`에서 벗어나 구체화된 첫 API입니다.

## `Study Signup` API 추가
현재 사용자가 `Study`에 참여 신청을 하는 API 입니다.
이 역시 `API_ENDPOINTS`에 추가 했습니다.
다만 현재 사용자를 읽으려면 인증/인가 기능이 구현되어야 하는데
이는 아직 미구현이라 신청 요청은 되지만
이미 신청한 스터디에 대해서는 `AlreadySignedup`(커스텀 에러 타입)(HTTP 400 Bad Request)를 반환할 것입니다.

Close #114 

### Additional context
# 신청 처리 로직 구체화가 필요합니다.
신청 내역과 실제 스터디 - 유저 배정 관계를 정의해야 합니다.
모델 Enrollment 추가가 어떨까 싶습니다.

# 폼 초기 데이터를 제공해야 합니다.
이전에 작성한 폼을 불러오고 수정할 수 있어야 합니다.

# 신청 철회 기능이 필요합니다.
신청을 취소할 수도 있어야 합니다.
이 페이지 하단 신청하기 버튼 옆에 취소하기 버튼도 추가하는 것이 좋겠습니다.