### PR TITLE
회원가입 페이지 개선 + clubroom 탭에서 footer 위치 수정

### DIFF
--- a/app/(main)/(light)/clubroom/page.tsx
+++ b/app/(main)/(light)/clubroom/page.tsx
@@ -6,6 +6,7 @@ export default function Clubroom() {
     <>
       <SectionBanner title="Clubroom" description="CoMit의 동아리방을 소개합니다!" />
       <ClubroomMainContent />
+      <div className="min-h-[81px]"></div> {/* footer를 딱맞게 내리기 위해 넣은 empty div */}
     </>
   )
 }

--- a/app/(main)/(light)/layout.tsx
+++ b/app/(main)/(light)/layout.tsx
@@ -10,7 +10,7 @@ export default function LightLayout({ children }: { children: React.ReactNode })
         style={{ WebkitOverflowScrolling: 'touch' }}
       >
         <div className="flex w-full justify-center">
-          <main className="relative flex min-h-dvh w-[1280px] flex-1 flex-col items-center">{children}</main>
+          <main className="relative flex w-[1280px] flex-1 flex-col items-center">{children}</main>
         </div>
         <Footer />
       </div>

--- a/app/(main)/(light)/signup/page.tsx
+++ b/app/(main)/(light)/signup/page.tsx
@@ -28,7 +28,6 @@ export interface FormData {
   password: string
   checkPassword: string
   consent: boolean
-  collapseButton: boolean
 }
 
 export default function Signup() {
@@ -48,18 +47,14 @@ export default function Signup() {
       email: '',
       password: '',
       checkPassword: '',
-      consent: false,
-      collapseButton: false
+      consent: false
     }
   })
 
-  const [watchPassword, watchCheckPassword, watchcollapseButton] = watch([
-    'password',
-    'checkPassword',
-    'collapseButton'
-  ])
+  const [watchPassword, watchCheckPassword] = watch(['password', 'checkPassword'])
   const [isCheckPasswordBlurred, setIsCheckPasswordBlurred] = useState(false)
   const [userName, setuserName] = useState('신규부원')
+  const [toggle, setToggle] = useState(false)
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
     // setError("");
@@ -277,12 +272,11 @@ export default function Signup() {
                 id="toggle"
                 type="checkbox"
                 className="hidden"
-                {...register('collapseButton', {
-                  required: false
-                })}
+                checked={toggle}
+                onChange={() => setToggle((prevState) => !prevState)}
               />
               <label htmlFor="toggle" className="cursor-pointer">
-                {watchcollapseButton ? (
+                {toggle ? (
                   <span className="absolute right-0 top-[1px] bg-cover text-[10px] sm:top-0 sm:mb-0 sm:text-[16px] ">
                     &#9650;
                   </span>
@@ -298,7 +292,7 @@ export default function Signup() {
                 <p className="text-[8px] text-destructive sm:text-xs/[18px]">{errors.consent.message}</p>
               )}
             </div>
-            {watchcollapseButton && (
+            {toggle && (
               <div className="mt-2 box-border w-full rounded-lg bg-[#fff] p-2 text-[8px]/[15px] sm:mt-4 sm:p-4 sm:text-[12px]/[20px]">
                 <p className="text-[#222]">
                   성균관대 코딩동아리 &apos;코밋(Comit)&apos; 회원 등록을 위해 아래와 같이 개인정보를 수집 및

--- a/app/(main)/(light)/signup/page.tsx
+++ b/app/(main)/(light)/signup/page.tsx
@@ -2,8 +2,9 @@
 
 import Image from 'next/image'
 import { useState } from 'react'
-import { SubmitHandler,useForm } from 'react-hook-form'
+import { SubmitHandler, useForm } from 'react-hook-form'
 
+import { cn } from '@/lib/utils'
 import Welcome from '@/public/welcome.svg'
 
 const simulatedApi = (data: FormData): Promise<{ success: boolean; data?: FormData; message?: string }> => {
@@ -27,6 +28,7 @@ export interface FormData {
   password: string
   checkPassword: string
   consent: boolean
+  collapseButton: boolean
 }
 
 export default function Signup() {
@@ -46,11 +48,16 @@ export default function Signup() {
       email: '',
       password: '',
       checkPassword: '',
-      consent: false
+      consent: false,
+      collapseButton: false
     }
   })
 
-  const [watchPassword, watchCheckPassword] = watch(['password', 'checkPassword'])
+  const [watchPassword, watchCheckPassword, watchcollapseButton] = watch([
+    'password',
+    'checkPassword',
+    'collapseButton'
+  ])
   const [isCheckPasswordBlurred, setIsCheckPasswordBlurred] = useState(false)
   const [userName, setuserName] = useState('신규부원')
 
@@ -69,46 +76,51 @@ export default function Signup() {
   }
 
   return (
-    <div className="flex min-h-screen w-screen justify-center bg-gray-100">
-      <div className="my-[60px] box-border w-[640px] border border-gray-200 bg-white px-10 py-[60px]">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-1 text-[32px]/[40px] font-normal">
+    <div className="flex w-screen justify-center bg-white sm:bg-gray-100">
+      <div className="box-border w-[440px] border-none border-gray-200 bg-white px-7 py-6 sm:w-full sm:border sm:pb-20 md:my-[42px] md:w-[640px] md:rounded-2xl md:py-[50px]">
+        <div className="mt-1 flex flex-col gap-1">
+          <div className="flex items-center gap-1 text-xl font-normal sm:text-[32px]/[40px]">
             <h3 className="inline-flex items-center">
-              <strong className="font-bold text-purple-600">{userName}</strong>님 반가워요
+              <strong className="font-bold text-primary">{userName}</strong>님 반가워요
             </h3>
-            <Image src={Welcome} alt="Welcome" />
+            <Image src={Welcome} alt="Welcome" className="-mt-1 h-6 w-6 sm:-mt-1.5 sm:h-9 sm:w-9" />
           </div>
-          <p className="text-[#6a6a6a]">동아리 활동을 시작하기 위한 기본 정보를 입력해 주세요!</p>
+          <p className="text-xs text-[#6a6a6a] sm:text-[16px]/[24px]">
+            동아리 활동을 시작하기 위한 기본 정보를 입력해 주세요!
+          </p>
         </div>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="my-12">
-            <div className="flex w-full flex-col gap-5">
+        <form onSubmit={handleSubmit(onSubmit)} className="mb-0 pb-0">
+          <div className="mb-6 mt-10">
+            <div className="flex w-full flex-col gap-2 sm:gap-[18px]">
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   이름(실명)&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('koreanName', {
                       required: '이름을 입력해주세요.',
                       onBlur: () => setuserName(getValues().koreanName)
                     })}
                     placeholder="실명을 입력해주세요."
-                    className="box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                    className={cn(
+                      'box-border rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:w-full sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                      errors.koreanName && 'border-2 border-destructive'
+                    )}
                   />
                   {errors.koreanName && (
-                    <p className="block text-xs/[18px] text-[#ff0000]">{errors.koreanName.message}</p>
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.koreanName.message}</p>
                   )}
                 </div>
               </div>
 
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   휴대폰번호&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('phoneNumber', {
                       required: '휴대폰번호를 입력해주세요.',
@@ -118,20 +130,23 @@ export default function Signup() {
                       }
                     })}
                     placeholder="예)01012345678"
-                    className="box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                    className={cn(
+                      'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                      errors.phoneNumber && 'border-2 border-destructive'
+                    )}
                   />
                   {errors.phoneNumber && (
-                    <p className="block text-xs/[18px] text-[#ff0000]">{errors.phoneNumber.message}</p>
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.phoneNumber.message}</p>
                   )}
                 </div>
               </div>
 
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   학번&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('studentID', {
                       required: '학번을 입력해주세요.',
@@ -141,92 +156,111 @@ export default function Signup() {
                       }
                     })}
                     placeholder="예)20xx331582"
-                    className="box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                    className={cn(
+                      'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                      errors.studentID && 'border-2 border-destructive'
+                    )}
                   />
                   {errors.studentID && (
-                    <p className="block text-xs/[18px] text-[#ff0000]">{errors.studentID.message}</p>
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.studentID.message}</p>
                   )}
                 </div>
               </div>
 
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   이메일&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <div className="flex flex-grow items-center gap-x-2">
                     <input
                       {...register('email', {
                         required: '이메일을 입력해주세요.',
                         pattern: {
-                          value: /^[a-zA-Z0-9+-\_.]/,
+                          value: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
                           message: '이메일을 다시 확인해주세요.'
                         }
                       })}
-                      placeholder="예)comit10282"
-                      className="box-border h-[48px] w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                      placeholder="예)comit10282@g.skku.edu"
+                      className={cn(
+                        'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                        errors.email && 'border-2 border-destructive'
+                      )}
                     />
-                    <div className="flex h-[54px] w-[138px] flex-shrink-0 justify-center rounded-lg border border-solid border-[#d2d2d2] px-[12px] py-[15px]">
-                      <span className=" block text-sm/[22px] text-gray-500">@g.skku.edu</span>
-                    </div>
                   </div>
-                  {errors.email && <p className="block text-xs/[18px] text-[#ff0000]">{errors.email.message}</p>}{' '}
+                  {errors.email && (
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.email.message}</p>
+                  )}{' '}
                 </div>
               </div>
 
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   비밀번호&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('password', {
                       required: '비밀번호를 입력해주세요.',
                       pattern: {
-                        value: /^[a-zA-Z\d]{8,20}$/i,
+                        value: /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,20}$/,
                         message: '유효한 비밀번호를 입력해주세요.'
                       }
                     })}
                     placeholder="영문자, 숫자 포함 8자 ~ 20자"
                     type="password"
-                    className="box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                    className={cn(
+                      'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                      errors.password && 'border-2 border-destructive'
+                    )}
                   />
-                  {errors.password && <p className="block text-xs/[18px] text-[#ff0000]">{errors.password.message}</p>}
+                  {errors.password && (
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.password.message}</p>
+                  )}
                 </div>
               </div>
 
               <div className="flex content-start gap-y-6">
-                <label className="relative box-border min-w-[120px] py-3 pb-3 text-base font-normal text-[#171717]">
+                <label className="relative box-border w-24 py-2 text-xs font-normal text-[#171717] sm:min-w-[120px] sm:py-3 sm:text-base">
                   비밀번호 확인&nbsp;
-                  <span className="inline-block text-[#ff0000]">*</span>
+                  <span className="inline-block text-destructive">*</span>
                 </label>
-                <div className="flex flex-grow flex-col gap-y-2">
+                <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('checkPassword', {
                       required: '비밀번호를 확인해주세요.',
                       onBlur: () => setIsCheckPasswordBlurred(true)
                     })}
+                    placeholder="비밀번호를 재입력해주세요."
                     type="password"
-                    className="box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-4 py-3 align-middle text-sm/[22px] tracking-normal outline-none"
+                    className={cn(
+                      'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
+                      (errors.checkPassword || (watchPassword !== watchCheckPassword && isCheckPasswordBlurred)) &&
+                        'border-2 border-destructive'
+                    )}
                   />
-                  {errors.checkPassword && (
-                    <p className="block text-xs/[18px] text-[#ff0000]">{errors.checkPassword.message}</p>
+                  {errors.checkPassword && watchCheckPassword == '' && (
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">
+                      {errors.checkPassword.message}
+                    </p>
                   )}
                   {watchPassword !== watchCheckPassword && watchCheckPassword && isCheckPasswordBlurred && (
-                    <p className="block text-xs/[18px] text-[#ff0000]">동일한 비밀번호를 입력해주세요.</p>
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">
+                      동일한 비밀번호를 입력해주세요.
+                    </p>
                   )}
                 </div>
               </div>
             </div>
           </div>
 
-          <div className="box-border rounded-lg bg-[#f7f7f7] px-[16px] py-[20px]">
+          <div className="box-border rounded-lg bg-[#f7f7f7] p-2 sm:p-4">
             <div className="relative flex w-full justify-between">
-              <div className="flex items-center text-[14px]/[22px] text-[#6a6a6a]">
+              <div className="flex items-center text-[10px]/[16px] text-[#6a6a6a] sm:text-[14px]/[22px]">
                 <input
-                  className="mr-2 h-5 w-5 text-purple-600 hover:cursor-pointer"
+                  className="mr-[6px] h-3 w-3 -translate-y-px text-primary hover:cursor-pointer sm:mr-2 sm:h-5 sm:w-5"
                   type="checkbox"
                   id="consent"
                   {...register('consent', {
@@ -239,55 +273,73 @@ export default function Signup() {
                   개인정보 수집 및 이용 동의
                 </label>
               </div>
-              <input id="toggle" type="checkbox" className="hidden" />
-              <label htmlFor="toggle" className="cursor-pointer checked:rotate-180">
-                <span className="absolute right-0 top-0 h-[18px] w-[18px] bg-[18px_18px]">&#9660;</span>
+              <input
+                id="toggle"
+                type="checkbox"
+                className="hidden"
+                {...register('collapseButton', {
+                  required: false
+                })}
+              />
+              <label htmlFor="toggle" className="cursor-pointer">
+                {watchcollapseButton ? (
+                  <span className="absolute right-0 top-[1px] bg-cover text-[10px] sm:top-0 sm:mb-0 sm:text-[16px] ">
+                    &#9650;
+                  </span>
+                ) : (
+                  <span className="absolute right-0 top-[1px] bg-cover text-[10px] sm:top-0 sm:mb-0 sm:text-[16px] ">
+                    &#9660;
+                  </span>
+                )}
               </label>
             </div>
             <div className="block">
-              {errors.consent && <p className="text-xs/[18px] text-[#ff0000]">{errors.consent.message}</p>}
+              {errors.consent && (
+                <p className="text-[8px] text-destructive sm:text-xs/[18px]">{errors.consent.message}</p>
+              )}
             </div>
-
-            <div className="mt-4 box-border w-full rounded-lg bg-[#fff] p-4 text-[12px]/[20px]">
-              <p className="text-[#222]">
-                성균관대 코딩동아리 &apos;코밋(Comit)&apos; 회원 등록을 위해 아래와 같이 개인정보를 수집 및 이용합니다.
-                동의를 거부할 권리가 있으며 동의 거부시 동아리 회원서비스 이용이 불가합니다.
-              </p>
-              <ul className="mt-2">
-                <li className="flex list-none items-center">
-                  <span className="-mt-[6px] flex items-center text-[30px] leading-[20px]">&#8901;</span>
-                  <p className="relative box-border  text-[#6a6a6a]">
-                    목적 : 스터디지원 및 프로필 공개등 동아리활동 서비스 제공, 각종 맞춤형 서비스 제공
-                  </p>
-                </li>
-                <li className="flex list-none items-center">
-                  <span className="-mt-[6px] flex items-center text-[30px] leading-[20px]">&#8901;</span>
-                  <p className="relative mt-1 box-border text-[#6a6a6a]">
-                    항목 : 이름, 휴대폰번호, 학번, 이메일, 학력사항
-                  </p>
-                </li>
-                <li className="flex list-none items-center">
-                  <span className="-mt-[6px] flex items-center text-[30px] leading-[20px]">&#8901;</span>
-                  <p className="relative mt-1 box-border text-[#6a6a6a]">
-                    보유 및 이용 기간 : 동아리 또는 회원 탈퇴시 즉시 파기
-                  </p>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          {errors.root && <p style={{ color: 'red' }}>{errors.root.message}</p>}
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="mt-5 w-full rounded-lg border border-solid border-[#d2d2d2] bg-purple-600 px-3 py-[15px]"
-          >
-            {isSubmitting ? (
-              <span className="block text-lg/[26px] font-bold text-[#fff]">제출중...</span>
-            ) : (
-              <span className="block text-lg/[26px] font-bold text-[#fff]">입력완료</span>
+            {watchcollapseButton && (
+              <div className="mt-2 box-border w-full rounded-lg bg-[#fff] p-2 text-[8px]/[15px] sm:mt-4 sm:p-4 sm:text-[12px]/[20px]">
+                <p className="text-[#222]">
+                  성균관대 코딩동아리 &apos;코밋(Comit)&apos; 회원 등록을 위해 아래와 같이 개인정보를 수집 및
+                  이용합니다. 동의를 거부할 권리가 있으며 동의 거부시 동아리 회원서비스 이용이 불가합니다.
+                </p>
+                <ul className="mt-2">
+                  <li className="flex list-none items-center">
+                    <span className="flex items-center text-[20px] sm:-mt-[6px] sm:text-[30px]">&#8901;</span>
+                    <p className="relative box-border  inline text-[#6a6a6a]">
+                      목적 : 스터디지원 및 프로필 공개등 동아리활동 서비스 제공, 각종 맞춤형 서비스 제공
+                    </p>
+                  </li>
+                  <li className="flex list-none items-center">
+                    <span className="flex items-center text-[20px] sm:-mt-[6px] sm:text-[30px]">&#8901;</span>
+                    <p className="relative mt-1 box-border inline text-[#6a6a6a]">
+                      항목 : 이름, 휴대폰번호, 학번, 이메일, 학력사항
+                    </p>
+                  </li>
+                  <li className="flex list-none items-center">
+                    <span className="flex items-center text-[20px] sm:-mt-[6px] sm:text-[30px]">&#8901;</span>
+                    <p className="relative mt-1 box-border inline text-[#6a6a6a]">
+                      보유 및 이용 기간 : 동아리 또는 회원 탈퇴시 즉시 파기
+                    </p>
+                  </li>
+                </ul>
+              </div>
             )}
-          </button>
+          </div>
+          <div className="flex justify-center">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="mt-3 w-1/3 rounded-lg border border-solid border-[#d2d2d2] bg-primary px-3 py-2 hover:opacity-80 sm:mt-5 sm:w-full sm:py-[15px]"
+            >
+              {isSubmitting ? (
+                <span className="block text-xs font-bold text-[#fff] sm:text-[20px]/[26px]">제출중...</span>
+              ) : (
+                <span className="block text-xs font-bold text-[#fff] sm:text-[20px]/[26px]">입력완료</span>
+              )}
+            </button>
+          </div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
### Description
회원가입 페이지 개선하였습니다.
<!-- Please explain what this PR is solving -->
Collapsible 기능 완성했습니다.
이메일 전체 주소 입력하는 걸로 수정했습니다.
rounded되도록 수정했습니다.
반응형으로 수정하였습니다.
Collapsible ui 완성했습니다. (DropDown ui는 원래 없어서 어떤 걸 말씀하셨는지 모르겠어요ㅠ)

추가 수정사항: 전체적인 패딩과 간격 수정, 버튼 호버 시 opacity 변경, validation 오류시 input border 빨간색으로 변경, password 영문 숫자 적어도 한 글자씩은 포함하게 수정, 에러 메시지 동시에 display되는 문제 해결
<!-- Please close the issue (Closes #<issue number>) -->
close #122 
### Additional context
clubroom 페이지에서 footer가 나올때까지 여백 생기는 문제 해결: footer 위치 화면에 맞게 변경해놓았습니다. 
나중에 layout.tsx 구조를 바꾸면 좋을 것 같습니다.

![image](https://github.com/user-attachments/assets/c7a8155a-c315-4ced-8449-e55c17bbdda2)
-> 이런 식으로 구성해서 항상 footer 위치가 정해지게 하는 것은 어떤가요?