### PR TITLE
feat(fe): edit login page UI

### DIFF
--- a/app/(main)/(dark)/login/page.tsx
+++ b/app/(main)/(dark)/login/page.tsx
@@ -53,30 +53,30 @@ export default function Login() {
   }
 
   return (
-    <div className="flex h-full w-full justify-center bg-black pt-8 text-white">
+    <div className="flex w-screen justify-center bg-white sm:bg-gray-100">
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="flex w-[88%] max-w-[480px] flex-col items-center gap-4 rounded-[32px] bg-[#121212] p-8 pb-8 sm:p-16 md:w-[480px]"
+        className="my-10 flex h-[720px] w-[480px] flex-col items-center gap-4 rounded-2xl bg-white p-8 sm:p-14"
       >
         <Image src={ComitOwl} alt="comit_owl" width={164} />
-        <p className="mb-6 text-center text-xl font-semibold sm:mb-12 sm:text-3xl">Log in to your account</p>
+        <p className="mb-6 text-center text-xl font-semibold sm:mb-12 sm:text-3xl">회원 로그인</p>
         <div className="flex w-full flex-col gap-1">
-          <p className="text-xl font-semibold">Email</p>
+          <p className="text-xl">이메일</p>
           <Input
             id="email"
             {...register('email')}
-            className="h-12 rounded-xl border-2 border-[#494949] bg-transparent sm:h-14"
+            className="h-12 rounded-xl border border-[#d2d2d2] bg-transparent sm:h-14"
             type="email"
           />
           {errors.email && <p className="text-sm text-red-500">{errors.email.message}</p>}
         </div>
         <div className="flex w-full flex-col gap-1">
-          <p className="text-xl font-semibold">Password</p>
+          <p className="text-xl">비밀번호</p>
           <div className="relative">
             <Input
               id="password"
               {...register('password')}
-              className="h-12 rounded-xl border-2 border-[#494949] bg-transparent sm:h-14"
+              className="h-12 rounded-xl border border-[#d2d2d2] bg-transparent sm:h-14"
               type={showPassword ? 'text' : 'password'}
             />
             {!showPassword ? (
@@ -95,11 +95,11 @@ export default function Login() {
           </div>
           {errors.password && <p className="text-sm text-red-500">{errors.password.message}</p>}
         </div>
-        <Button className="my-4 h-12 w-full rounded-xl text-xl font-semibold sm:h-14">Log In</Button>
+        <Button className="my-4 h-12 w-full rounded-xl text-xl font-semibold sm:h-14">로그인</Button>
         <div className="flex items-center justify-between">
-          <p>Don&apos;t have an account?</p>
-          <Button variant="link" className="text-white" asChild>
-            <Link href="/signup">Sign Up</Link>
+          <p>계정이 없으신가요?</p>
+          <Button variant="link" className="text-base font-bold" asChild>
+            <Link href="/signup">회원가입</Link>
           </Button>
         </div>
       </form>

--- a/app/(main)/(light)/signup/page.tsx
+++ b/app/(main)/(light)/signup/page.tsx
@@ -97,7 +97,7 @@ export default function Signup() {
                       required: '이름을 입력해주세요.',
                       onBlur: () => setuserName(getValues().username)
                     })}
-                    placeholder="실명을 입력해주세요."
+                    placeholder="실명을 입력해주세요"
                     className={cn(
                       'box-border rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:w-full sm:px-4 sm:py-3 sm:text-sm/[22px]',
                       errors.username && 'border-2 border-destructive'
@@ -117,13 +117,13 @@ export default function Signup() {
                 <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
                     {...register('phoneNumber', {
-                      required: '휴대폰번호를 입력해주세요.',
+                      required: '휴대폰 번호를 입력해주세요.',
                       pattern: {
                         value: /^010\d{8}$/,
-                        message: '휴대폰번호를 다시 확인해주세요.'
+                        message: '휴대폰 번호를 다시 확인해주세요.'
                       }
                     })}
-                    placeholder="예)01012345678"
+                    placeholder="휴대폰 번호 입력 ('-' 제외 11자리)"
                     className={cn(
                       'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
                       errors.phoneNumber && 'border-2 border-destructive'
@@ -149,7 +149,7 @@ export default function Signup() {
                         message: '학번을 다시 확인해주세요.'
                       }
                     })}
-                    placeholder="예)20xx331582"
+                    placeholder="학번 입력 (숫자 10자)"
                     className={cn(
                       'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
                       errors.studentId && 'border-2 border-destructive'
@@ -176,7 +176,7 @@ export default function Signup() {
                           message: '이메일을 다시 확인해주세요.'
                         }
                       })}
-                      placeholder="예)comit10282@g.skku.edu"
+                      placeholder="이메일 주소 입력 (로그인용)"
                       className={cn(
                         'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
                         errors.email && 'border-2 border-destructive'
@@ -203,7 +203,7 @@ export default function Signup() {
                         message: '유효한 비밀번호를 입력해주세요.'
                       }
                     })}
-                    placeholder="영문자, 숫자 포함 8자 ~ 20자"
+                    placeholder="비밀번호 입력 (영문자, 숫자 포함 8~20자)"
                     type="password"
                     className={cn(
                       'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
@@ -227,7 +227,7 @@ export default function Signup() {
                       required: '비밀번호를 확인해주세요.',
                       onBlur: () => setIsCheckPasswordBlurred(true)
                     })}
-                    placeholder="비밀번호를 재입력해주세요."
+                    placeholder="비밀번호 재입력"
                     type="password"
                     className={cn(
                       'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',

--- a/app/(main)/(light)/signup/page.tsx
+++ b/app/(main)/(light)/signup/page.tsx
@@ -21,9 +21,9 @@ const simulatedApi = (data: FormData): Promise<{ success: boolean; data?: FormDa
 }
 
 export interface FormData {
-  koreanName: string
+  username: string
   phoneNumber: string
-  studentID: string
+  studentId: string
   email: string
   password: string
   checkPassword: string
@@ -41,9 +41,9 @@ export default function Signup() {
   } = useForm<FormData>({
     mode: 'onBlur',
     defaultValues: {
-      koreanName: '',
+      username: '',
       phoneNumber: '',
-      studentID: '',
+      studentId: '',
       email: '',
       password: '',
       checkPassword: '',
@@ -93,18 +93,18 @@ export default function Signup() {
                 </label>
                 <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
-                    {...register('koreanName', {
+                    {...register('username', {
                       required: '이름을 입력해주세요.',
-                      onBlur: () => setuserName(getValues().koreanName)
+                      onBlur: () => setuserName(getValues().username)
                     })}
                     placeholder="실명을 입력해주세요."
                     className={cn(
                       'box-border rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:w-full sm:px-4 sm:py-3 sm:text-sm/[22px]',
-                      errors.koreanName && 'border-2 border-destructive'
+                      errors.username && 'border-2 border-destructive'
                     )}
                   />
-                  {errors.koreanName && (
-                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.koreanName.message}</p>
+                  {errors.username && (
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.username.message}</p>
                   )}
                 </div>
               </div>
@@ -142,7 +142,7 @@ export default function Signup() {
                 </label>
                 <div className="flex flex-grow flex-col gap-y-1 sm:gap-y-2">
                   <input
-                    {...register('studentID', {
+                    {...register('studentId', {
                       required: '학번을 입력해주세요.',
                       pattern: {
                         value: /^20\d{8}$/,
@@ -152,11 +152,11 @@ export default function Signup() {
                     placeholder="예)20xx331582"
                     className={cn(
                       'box-border w-full rounded-lg border border-solid border-[#d2d2d2] px-3 py-2 align-middle text-xs tracking-normal outline-none sm:px-4 sm:py-3 sm:text-sm/[22px]',
-                      errors.studentID && 'border-2 border-destructive'
+                      errors.studentId && 'border-2 border-destructive'
                     )}
                   />
-                  {errors.studentID && (
-                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.studentID.message}</p>
+                  {errors.studentId && (
+                    <p className="block text-[8px] text-destructive sm:text-xs/[18px]">{errors.studentId.message}</p>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
* 로그인 페이지 UI 수정
![image](https://github.com/user-attachments/assets/b7e2f59f-f07c-430f-9390-a35f109a40a6)

* 회원가입 폼 스키마 변경 (백엔드에 맞춤)
koreanname -> username / studentID -> studentId

* 회원가입 input placeholder 수정
![image](https://github.com/user-attachments/assets/504d78d6-fa95-4194-90b5-abe0569b7a34)
입력 예시보다는 형식에 집중하는 게 좋을 것 같아서 수정했습니다!
피드백 부탁드려요~

<!-- Please close the issue (Closes #<issue number>) -->
Closes #139 

### Additional context
로그인 페이지를 light로 바꾸면서 dark에서 light 폴더로 옮겨야 하지만
지호형이랑 충돌날 거 같아서 일단 위치를 옮기지는 않았습니다! 

<!-- Please specify the point to focus during code review -->
