### PR TITLE
feat(fe): change sidebar to use shadcn sheet

### DIFF
--- a/components/admin/Sidebar/NavLink.tsx
+++ b/components/admin/Sidebar/NavLink.tsx
@@ -9,12 +9,14 @@ const NavLink = ({
   href,
   icon,
   children,
-  className
+  className,
+  onClick
 }: {
   href: string
   icon: React.ReactNode
   children: React.ReactNode
   className?: string
+  onClick?: () => void
 }) => {
   const pathname = usePathname()
   const [_, parentPathname, childPathname] = pathname.split('/')
@@ -27,6 +29,7 @@ const NavLink = ({
     <Link
       href={href}
       className={cn('flex items-center justify-start gap-x-4 hover:text-primary', activeClass, className)}
+      onClick={onClick}
     >
       {icon}
       <p className="text-lg font-bold">{children}</p>

--- a/components/admin/Sidebar/index.tsx
+++ b/components/admin/Sidebar/index.tsx
@@ -1,25 +1,46 @@
+'use client'
+
+import { useState } from 'react'
 import { GoBook } from 'react-icons/go'
 import { IoHomeOutline } from 'react-icons/io5'
 import { IoPeopleOutline } from 'react-icons/io5'
+import { LiaAngleDoubleRightSolid } from 'react-icons/lia'
 
 import NavLink from '@/components/admin/Sidebar/NavLink'
+import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { ROUTES } from '@/constants/routes'
 import { cn } from '@/lib/utils'
 
 export default function SideBar({ className }: { className?: string }) {
+  const [open, setOpen] = useState<boolean>(false)
   return (
-    <div className={cn(className, 'border-e p-5')}>
-      <div className="flex flex-col gap-y-6">
-        <NavLink href={ROUTES.ADMIN.DASHBOARD.url} icon={<IoHomeOutline size={28} />}>
-          Dashboard
-        </NavLink>
-        <NavLink href={ROUTES.ADMIN.STUDY.url} icon={<GoBook size={28} />}>
-          Study
-        </NavLink>
-        <NavLink href={ROUTES.ADMIN.USER.url} icon={<IoPeopleOutline size={28} />}>
-          User
-        </NavLink>
-      </div>
-    </div>
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger>
+        <div className="p-4">
+          <LiaAngleDoubleRightSolid size={24} className="text-gray-500 hover:text-primary" />
+        </div>
+      </SheetTrigger>
+      <SheetContent side={'left'} className="w-60">
+        <SheetTitle />
+        <SheetDescription />
+        <div className={cn(className, 'p-5')}>
+          <div className="flex flex-col gap-y-6">
+            <NavLink
+              href={ROUTES.ADMIN.DASHBOARD.url}
+              icon={<IoHomeOutline size={28} />}
+              onClick={() => setOpen(false)}
+            >
+              Dashboard
+            </NavLink>
+            <NavLink href={ROUTES.ADMIN.STUDY.url} icon={<GoBook size={28} />} onClick={() => setOpen(false)}>
+              Study
+            </NavLink>
+            <NavLink href={ROUTES.ADMIN.USER.url} icon={<IoPeopleOutline size={28} />} onClick={() => setOpen(false)}>
+              User
+            </NavLink>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { X } from 'lucide-react'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm'
+      }
+    },
+    defaultVariants: {
+      side: 'right'
+    }
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ side = 'right', className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+        {children}
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+)
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+)
+SheetHeader.displayName = 'SheetHeader'
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+)
+SheetFooter.displayName = 'SheetFooter'
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title ref={ref} className={cn('text-lg font-semibold text-foreground', className)} {...props} />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.1",
-        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-icons": "^1.3.0",
@@ -705,6 +705,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
       "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.1",
-    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-hover-card": "^1.1.1",
     "@radix-ui/react-icons": "^1.3.0",


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
shadcn의 sheet를 사용해서 왼쪽에서 사이드바가 나오도록 수정했습니다
NavLink를 클릭하거나 사이드바 외부를 클릭하면 사이드바가 다시 사라집니다
요구하신 게 이게 맞는지는 잘 모르겠지만 나쁘지 않아 보여서 올립니당

https://github.com/user-attachments/assets/4a380da2-ab06-4be1-b34e-31650de41cf5

<!-- Please close the issue (Closes #<issue number>) -->
Closes #146 
### Additional context

<!-- Please specify the point to focus during code review -->
