### PR TITLE
chore: add redirection logic at signup page

### DIFF
--- a/app/(main)/signup/page.tsx
+++ b/app/(main)/signup/page.tsx
@@ -2,7 +2,8 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import Image from 'next/image'
-import { signIn } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { signIn, useSession } from 'next-auth/react'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -34,6 +35,11 @@ export default function Signup() {
     mode: 'onBlur',
     resolver: zodResolver(signUpSchema)
   })
+  const session = useSession()
+  const router = useRouter()
+  if (session.status === 'authenticated') {
+    router.push('/')
+  }
 
   const [watchPassword, watchConfirmPassword] = watch(['password', 'confirmPassword'])
   const [isConfirmPasswordBlurred, setIsConfirmPasswordBlurred] = useState(false)


### PR DESCRIPTION
### Description
백엔드에서 AT, RT를 보내주고 원래대로 회원가입 시 바로 로그인 됩니다.
다만 로그인 된 상태에서 회원가입 페이지로 이동하면 자동으로 홈으로 리다이렉트 됩니다.
<!-- Please explain what this PR is solving -->

<!-- Please close the issue (Closes #<issue number>) -->

### Additional context

<!-- Please specify the point to focus during code review -->
