### PR TITLE
fix: show toast when signup failed

### DIFF
--- a/app/(main)/profile/_components/ProfileCards.tsx
+++ b/app/(main)/profile/_components/ProfileCards.tsx
@@ -65,7 +65,8 @@ const ProfileCards = ({ session, user }: ProfileProps) => {
     if (profileImage === user.profileImage && bio === user.bio) {
       toast({
         title: '프로필 수정 실패',
-        description: '변경된 정보가 없습니다!'
+        description: '변경된 정보가 없습니다!',
+        variant: 'destructive'
       })
       return
     }

--- a/app/(main)/signup/page.tsx
+++ b/app/(main)/signup/page.tsx
@@ -12,6 +12,7 @@ import { FaRegEye, FaRegEyeSlash } from 'react-icons/fa'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { useToast } from '@/components/ui/use-toast'
 import { extendedSignUpSchema } from '@/constants/zodSchema/signup'
 import { cn } from '@/lib/utils'
 import Welcome from '@/public/welcome.svg'
@@ -44,6 +45,8 @@ export default function Signup() {
     router.push('/')
   }
 
+  const { toast } = useToast()
+
   const [watchPassword, watchConfirmPassword] = watch(['password', 'confirmPassword'])
   const [isConfirmPasswordBlurred, setIsConfirmPasswordBlurred] = useState(false)
   const [viewPassword, setViewPassword] = useState(false)
@@ -61,14 +64,18 @@ export default function Signup() {
         email: data.email,
         password: data.password
       })
-
-      if (res) {
-        console.log(res)
+      if (res?.error) {
+        toast({
+          title: '회원가입 실패',
+          description: '이미 가입된 회원 정보입니다.',
+          variant: 'destructive'
+        })
       }
     } catch (error) {
-      setError('root', {
-        type: 'manual',
-        message: '로그인 중 오류 발생'
+      toast({
+        title: '회원가입 실패',
+        description: '회원가입 중 오류가 발생했습니다.',
+        variant: 'destructive'
       })
     }
   }


### PR DESCRIPTION
### Description

<!-- Please explain what this PR is solving -->
이미 가입된 정보로 회원가입 시도 시 destructive toast를 띄웁니다.
<!-- Please close the issue (Closes #<issue number>) -->
Closes #183 
### Additional context

<!-- Please specify the point to focus during code review -->
