### PR TITLE
179 revive study open preview card

### DIFF
--- a/app/(main)/study/open/page.tsx
+++ b/app/(main)/study/open/page.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Clock } from 'lucide-react'
 import Image from 'next/image'
-import { useRouter } from 'next/navigation'
+import { redirect, useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { SetStateAction, useRef, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -70,6 +70,8 @@ const levelOptions: Level[] = ['초급', '중급', '고급']
 
 export default function OpenStudy() {
   const session = useSession()
+  const canOpenStudy = session.data?.role ? ['ROLE_VERIFIED', 'ROLE_ADMIN'].includes(session.data?.role) : false
+
   const router = useRouter()
   const { toast } = useToast()
 
@@ -194,6 +196,9 @@ export default function OpenStudy() {
     }
   }
 
+  if (!canOpenStudy) {
+    redirect(ROUTES.STUDY.index.url)
+  }
   return (
     <div className="flex flex-col items-center">
       <SectionBanner title="Open Study" description="새로운 스터디 분반을 개설합니다!" />

--- a/app/(main)/study/open/page.tsx
+++ b/app/(main)/study/open/page.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod'
 
 import ScrollToTopButton from '@/components/common/ScrollToTopButton'
 import SectionBanner from '@/components/common/SectionBanner'
+import StudyCard from '@/components/common/StudyCard'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -94,7 +95,6 @@ export default function OpenStudy() {
   })
   const fileHandler = useSupabaseFile({ pathPrefix: 'image/study' })
 
-  // TODO: study API 연결
   const onSubmit = async (data: StudyForm) => {
     document.getElementById('closeDialog')?.click()
 
@@ -206,7 +206,9 @@ export default function OpenStudy() {
         <div className="flex gap-8 max-md:flex-col max-md:gap-4">
           <div className="flex flex-col gap-1">
             <p className="text-xl font-semibold">이미지</p>
-            <div
+            <Button
+              type="button"
+              variant="outline"
               onClick={handleClick}
               className="flex h-52 w-52 items-center justify-center overflow-hidden rounded-lg border border-slate-300"
             >
@@ -215,7 +217,7 @@ export default function OpenStudy() {
               ) : (
                 <Image src={image} width={208} height={208} alt={image} className="h-full w-full object-cover" />
               )}
-            </div>
+            </Button>
             <Input className="hidden" accept="image/*" type="file" ref={fileRef} onChange={handleFileChange} />
             {errors.imageSrc && <p className="text-sm text-red-500">{errors.imageSrc.message}</p>}
           </div>
@@ -402,6 +404,7 @@ export default function OpenStudy() {
               <Button
                 type="button"
                 className="px-8 font-extrabold"
+                disabled={!isValid}
                 onClick={() => {
                   trigger()
                   isValid && setStackError('')
@@ -410,33 +413,47 @@ export default function OpenStudy() {
                 제출하기
               </Button>
             </AlertDialogTrigger>
-            <AlertDialogContent className="flex flex-col p-8 sm:max-w-[425px]">
+            <AlertDialogContent className="flex flex-col p-3 sm:max-w-[425px] lg:p-8">
               <AlertDialogHeader>
                 <AlertDialogTitle>제출하시겠습니까?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  스터디 개설이 승인되기 전까지 내용 수정 및 삭제가 불가하며, 반드시 내용을 수정하거나 삭제해야 하는
-                  경우 관리자에게 문의해주세요.
+                  스터디 개설이 되는 즉시 스터디가 모집 중으로 변경됩니다. 한 번 개설된 스터디는 삭제할 수 없습니다.
                 </AlertDialogDescription>
               </AlertDialogHeader>
-              {/* TODO: study dialog 추가 */}
+
+              {/* 미리보기 카드 */}
               <div className="flex justify-center">
-                {/* TODO: study open에 맞게 StudyCard 수정 */}
-                {/* <StudyCard
-                  campus={getValues('campus') || ''}
-                  day={getValues('day') || ''}
-                  imageSrc={
-                    getValues('imageSrc') ||
-                    // TODO: 다른 이미지 저장으로 대체
-                    'https://github.com/skku-comit/comit-website/assets/97675977/5ac14e32-87e6-40c0-9572-33cab7822abd'
-                  }
-                  endTime={getValues('endTime') || ''}
-                  level={getValues('level') || ''}
-                  stacks={getValues('stacks') || ''}
-                  startTime={getValues('startTime') || ''}
-                  title={getValues('title') || ''}
-                /> */}
+                <StudyCard
+                  study={{
+                    id: 0,
+                    campus: getValues('campus') || '공통',
+                    day: getValues('day') || '월',
+                    description: getValues('description') || '',
+                    endTime: getValues('endTime') || '00:00',
+                    imageSrc: getValues('imageSrc') || '',
+                    isRecruiting: true,
+                    level: getValues('level') || '초급',
+                    mentor: {
+                      bio: '',
+                      email: '',
+                      github: '',
+                      id: 0,
+                      phoneNumber: '',
+                      position: '',
+                      profileImage: '',
+                      role: 'ROLE_MEMBER',
+                      studentId: '',
+                      isStaff: false,
+                      username: ''
+                    },
+                    semester: '1',
+                    stacks: getValues('stacks') || [],
+                    startTime: getValues('startTime') || '00:00',
+                    title: getValues('title') || ''
+                  }}
+                />
               </div>
-              {!isValid && <p className="text-sm text-red-500">모든 항목을 입력해주세요</p>}
+              {!isValid && <p className="text-sm text-destructive">모든 항목을 입력해주세요</p>}
               <AlertDialogFooter>
                 <AlertDialogCancel>취소</AlertDialogCancel>
                 <AlertDialogAction type="submit" onClick={handleSubmit(onSubmit)} disabled={!isValid}>

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -1,6 +1,8 @@
 import { FaGithub, FaInstagram, FaRegCopyright } from 'react-icons/fa'
 import { RiKakaoTalkFill } from 'react-icons/ri'
 
+import { GITHUB_LINK, INSTAGRAM_LINK, KAKAO_OPEN_CHAT_LINK } from '@/constants/social'
+
 interface FooterProp {
   height: string
 }
@@ -14,13 +16,13 @@ export default function Footer({ height }: FooterProp) {
           <p> 2024 COMIT All rights reserved.</p>
         </div>
         <div className="flex items-center justify-center gap-4">
-          <a rel="noreferrer noopener" target="_blank" href="https://github.com/skku-comit">
+          <a rel="noreferrer noopener" target="_blank" href={GITHUB_LINK}>
             <FaGithub className="text-xl text-white" />
           </a>
-          <a rel="noreferrer noopener" target="_blank" href="https://open.kakao.com/o/g8OGIihg">
+          <a rel="noreferrer noopener" target="_blank" href={KAKAO_OPEN_CHAT_LINK}>
             <RiKakaoTalkFill className="text-xl text-white" />
           </a>
-          <a rel="noreferrer noopener" target="_blank" href="https://www.instagram.com/skku_comit/">
+          <a rel="noreferrer noopener" target="_blank" href={INSTAGRAM_LINK}>
             <FaInstagram className="text-xl text-white" />
           </a>
         </div>

--- a/components/common/Study/DescriptionCard.tsx
+++ b/components/common/Study/DescriptionCard.tsx
@@ -1,7 +1,18 @@
 import Link from 'next/link'
 import { FaCheck } from 'react-icons/fa6'
+import { MdOutlineDangerous } from 'react-icons/md'
 
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+import { ROUTES } from '@/constants/routes'
+import { auth } from '@/lib/auth/auth'
 
 type Description = {
   title: string
@@ -10,12 +21,36 @@ type Description = {
   notices: string[]
 }
 
+const StudyOpenRejectDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="self-center font-semibold sm:absolute sm:bottom-4 sm:right-4">
+          스터디 개설
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-x-1 text-destructive">
+            <MdOutlineDangerous size={24} />
+            권한 없음
+          </DialogTitle>
+        </DialogHeader>
+        <DialogDescription>관리자 인증이 필요합니다.</DialogDescription>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export interface DescriptionCardProps {
   description: Description
   hasButton: boolean
 }
 
-export default function DescriptionCard({ description, hasButton }: DescriptionCardProps) {
+export default async function DescriptionCard({ description, hasButton }: DescriptionCardProps) {
+  const session = await auth()
+  const canOpenStudy = session?.role ? ['ROLE_VERIFIED', 'ROLE_ADMIN'].includes(session?.role) : false
+
   return (
     <div className="relative flex w-full max-w-[550px]  flex-col items-start justify-start gap-2 rounded-3xl bg-[#F4F7FA] px-4 py-6 shadow-md sm:gap-4 sm:px-6 lg:w-[45%] xl:p-10">
       <div className="flex items-center gap-2 text-2xl font-extrabold sm:text-3xl">
@@ -25,17 +60,20 @@ export default function DescriptionCard({ description, hasButton }: DescriptionC
       <div className="text-[15px] font-semibold text-black sm:text-xl">{description.question}</div>
       <div className="text-pretty text-[15px] font-semibold text-black sm:text-xl">{description.recommendation}</div>
       <ul className="list-outside list-disc text-wrap pl-5 sm:mt-5">
-        {description.notices.map((notice) => (
+        {description.notices.map((notice: string) => (
           <li key={notice} className="mb-2 text-pretty text-sm text-gray-700 sm:mb-3 md:text-base">
             {notice}
           </li>
         ))}
       </ul>
-      {hasButton && (
-        <Button asChild variant="outline" className="self-center font-semibold sm:absolute sm:bottom-4 sm:right-4">
-          <Link href="study/open">스터디 개설</Link>
-        </Button>
-      )}
+      {hasButton &&
+        (canOpenStudy ? (
+          <Button asChild variant="outline" className="self-center font-semibold sm:absolute sm:bottom-4 sm:right-4">
+            <Link href={ROUTES.STUDY.OPEN.url}>스터디 개설</Link>
+          </Button>
+        ) : (
+          <StudyOpenRejectDialog />
+        ))}
     </div>
   )
 }

--- a/components/common/Study/DescriptionCard.tsx
+++ b/components/common/Study/DescriptionCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { FaCheck } from 'react-icons/fa6'
 import { MdOutlineDangerous } from 'react-icons/md'
+import { RiKakaoTalkFill } from 'react-icons/ri'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -12,6 +13,7 @@ import {
   DialogTrigger
 } from '@/components/ui/dialog'
 import { ROUTES } from '@/constants/routes'
+import { KAKAO_OPEN_CHAT_LINK } from '@/constants/social'
 import { auth } from '@/lib/auth/auth'
 
 type Description = {
@@ -36,7 +38,20 @@ const StudyOpenRejectDialog = () => {
             권한 없음
           </DialogTitle>
         </DialogHeader>
-        <DialogDescription>관리자 인증이 필요합니다.</DialogDescription>
+        <DialogDescription asChild>
+          <div>
+            관리자 인증이 필요합니다.{<br />}
+            스터디 개설을 희망하시면 임원진에게 카카오톡으로 권한을 요청해주세요.
+            <div className="flex items-center justify-end">
+              <Button asChild className="mt-3 self-center font-semibold">
+                <Link href={KAKAO_OPEN_CHAT_LINK} target="_blank">
+                  <RiKakaoTalkFill size={24} className="me-1" />
+                  카카오톡으로 요청
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </DialogDescription>
       </DialogContent>
     </Dialog>
   )

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -22,6 +22,10 @@ export const ROUTES = {
       name: '스터디',
       url: '/study'
     },
+    OPEN: {
+      name: '스터디 개설',
+      url: '/study/open'
+    },
     SIGNUP: (id: string) => ({
       name: '스터디 참여',
       url: `/study/${id}/signup`

--- a/constants/social.ts
+++ b/constants/social.ts
@@ -1,0 +1,3 @@
+export const GITHUB_LINK = 'https://github.com/skku-comit'
+export const KAKAO_OPEN_CHAT_LINK = 'https://open.kakao.com/o/g8OGIihg'
+export const INSTAGRAM_LINK = 'https://www.instagram.com/skku_comit/'


### PR DESCRIPTION
### Description
## 스터디 생성성 시 미리보기 카드 표시
![image](https://github.com/user-attachments/assets/76f103ba-ab23-4612-8b31-2c938765ad25)
이전에 주석 처리된 코드를 해제 및 조정했습니다.
<!-- Please close the issue (Closes #<issue number>) -->
Close #179 

## 스터디 생성 페이지 접근 권한 설정
- `role === "ROLE_ADMIN"` 이거나 `role ==="ROLE_VERIFIED"`인 경우에만 스터디 생성 가능합니다.
- 물론 스터디 개설 페이지 내에서도 권한이 없으면 리다이렉트 됩니다.
- 또한 카카오톡 오픈 채팅방으로 바로 이동 할 수 있는 링크도 생성했습니다.
- 
![image](https://github.com/user-attachments/assets/d17c01e3-6de1-45d1-afce-546e4d2995c5)



### Additional context

<!-- Please specify the point to focus during code review -->
